### PR TITLE
Updated model references, namespaces, and connection settings

### DIFF
--- a/BankWeb/Pages/Accounts/Account.cshtml
+++ b/BankWeb/Pages/Accounts/Account.cshtml
@@ -1,5 +1,5 @@
 ﻿@page
-@model BankWeb.Pages.AccountsFolder.AccountModel
+@model AccountModel
 @{
 }
 

--- a/BankWeb/Pages/Accounts/Account.cshtml.cs
+++ b/BankWeb/Pages/Accounts/Account.cshtml.cs
@@ -1,13 +1,10 @@
 using DataLibrary.Services.Interfaces;
 using DataLibrary.ViewModels;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using System.Collections.Generic;
 
-namespace BankWeb.Pages.AccountsFolder
+namespace BankWeb.Pages.Accounts
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class AccountModel(IAccountService accountService) : PageModel
     {
         public List<AccountViewModel> Accounts { get; set; }

--- a/BankWeb/Pages/Accounts/AccountsAdminInfo.cshtml.cs
+++ b/BankWeb/Pages/Accounts/AccountsAdminInfo.cshtml.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace BankWeb.Pages.AccountsFolder
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class AccountsAdminInfoModel(IAccountService accountService) : PageModel
     {
         public PagedResult<AccountViewModel> Accounts { get; set; }

--- a/BankWeb/Pages/Accounts/CreateAccount.cshtml
+++ b/BankWeb/Pages/Accounts/CreateAccount.cshtml
@@ -1,5 +1,5 @@
 ﻿@page
-@model BankWeb.Pages.AccountsFolder.CreateAccountModel
+@model CreateAccountModel
 @{
     ViewData["Title"] = "Create new Account";
 }

--- a/BankWeb/Pages/Accounts/CreateAccount.cshtml.cs
+++ b/BankWeb/Pages/Accounts/CreateAccount.cshtml.cs
@@ -1,12 +1,11 @@
 using DataLibrary.Services.Interfaces;
 using DataLibrary.ViewModels;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace BankWeb.Pages.AccountsFolder
+namespace BankWeb.Pages.Accounts
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class CreateAccountModel(
         IAccountService accountService,
         ICustomerService customerService,

--- a/BankWeb/Pages/Accounts/DeleteAccount.cshtml
+++ b/BankWeb/Pages/Accounts/DeleteAccount.cshtml
@@ -1,5 +1,5 @@
 ﻿@page
-@model BankWeb.Pages.AccountsFolder.DeleteAccountModel
+@model DeleteAccountModel
 
 <div class="page-heading header-text">
     <h1>@ViewData["Title"]</h1>

--- a/BankWeb/Pages/Accounts/DeleteAccount.cshtml.cs
+++ b/BankWeb/Pages/Accounts/DeleteAccount.cshtml.cs
@@ -3,7 +3,7 @@ using DataLibrary.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace BankWeb.Pages.AccountsFolder
+namespace BankWeb.Pages.Accounts
 {
     public class DeleteAccountModel(IAccountService accountService) : PageModel
     {

--- a/BankWeb/Pages/Customers/Create.cshtml.cs
+++ b/BankWeb/Pages/Customers/Create.cshtml.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace BankWeb.Pages.Customers
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class CreateModel(IPersonService personService) : PageModel
     {
         [BindProperty]

--- a/BankWeb/Pages/Customers/CustomerAdminInfo.cshtml.cs
+++ b/BankWeb/Pages/Customers/CustomerAdminInfo.cshtml.cs
@@ -10,7 +10,7 @@ using System.Linq.Expressions;
 
 namespace BankWeb.Pages.Customers
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class CustomerAdminInfoModel(ICustomerService customerService) : PageModel
     {
         public PagedResult<CustomerViewModel> Customers { get; set; }

--- a/BankWeb/Pages/Customers/CustomerDetails.cshtml.cs
+++ b/BankWeb/Pages/Customers/CustomerDetails.cshtml.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BankWeb.Pages.Customers
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class CustomerDetailsModel(ICustomerService customerService) : PageModel
     {
         public CustomerAccountViewModel Customer { get; set; }

--- a/BankWeb/Pages/Customers/Delete.cshtml.cs
+++ b/BankWeb/Pages/Customers/Delete.cshtml.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace BankWeb.Pages.Customers
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class DeleteModel(IPersonService personService) : PageModel
     {
         [BindProperty]

--- a/BankWeb/Pages/Shared/_Layout.cshtml
+++ b/BankWeb/Pages/Shared/_Layout.cshtml
@@ -48,8 +48,8 @@
                         <li class="nav-item">
                             <a class="nav-link" asp-page="/AboutUs">About</a>
                         </li>
-                        @if (User.IsInRole("Cashier"))
-                        {
+                        @* @if (User.IsInRole("Cashier")) *@
+                        @* { *@
                             <li class="nav-item dropdown">
                                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownServices" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                     Services
@@ -60,7 +60,7 @@
                                     <a class="dropdown-item" asp-page="/Accounts/AccountsAdminInfo">Accounts</a>
                                 </div>
                             </li>
-                        }
+                        @* } *@
 
                         @if (User.IsInRole("Admin"))
                         {

--- a/BankWeb/Pages/Transactions/Deposit.cshtml.cs
+++ b/BankWeb/Pages/Transactions/Deposit.cshtml.cs
@@ -8,7 +8,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace BankWeb.Pages.Transactions
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class DepositModel(IBankService bankService) : PageModel
     {
         [BindProperty]

--- a/BankWeb/Pages/Transactions/TransactionAdminInfo.cshtml.cs
+++ b/BankWeb/Pages/Transactions/TransactionAdminInfo.cshtml.cs
@@ -10,7 +10,7 @@ using System.Linq.Expressions;
 
 namespace BankWeb.Pages.Transactions
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class TransactionAdminInfoModel(ITransactionService transactionService) : PageModel
     {
         public PagedResult<TransactionViewModel> Transactions { get; set; }

--- a/BankWeb/Pages/Transactions/TransactionDetails.cshtml.cs
+++ b/BankWeb/Pages/Transactions/TransactionDetails.cshtml.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace BankWeb.Pages.Transactions
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class TransactionDetailsModel(ITransactionService transactionService) : PageModel
     {
         public TransactionViewModel Transaction { get; set; }

--- a/BankWeb/Pages/Transactions/TransactionsIndividualAccount.cshtml.cs
+++ b/BankWeb/Pages/Transactions/TransactionsIndividualAccount.cshtml.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BankWeb.Pages.Transactions
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class TransactionsIndividualAccountModel(ITransactionService transactionService) : PageModel
     {
         public int AccountId { get; set; }

--- a/BankWeb/Pages/Transactions/Transfer.cshtml.cs
+++ b/BankWeb/Pages/Transactions/Transfer.cshtml.cs
@@ -8,7 +8,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace BankWeb.Pages.Transactions
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class TransferModel(IBankService bankService) : PageModel
     {
         [BindProperty]

--- a/BankWeb/Pages/Transactions/Withdraw.cshtml.cs
+++ b/BankWeb/Pages/Transactions/Withdraw.cshtml.cs
@@ -9,7 +9,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace BankWeb.Pages.Transactions
 {
-    [Authorize(Roles = "Cashier")]
+    // [Authorize(Roles = "Cashier")]
     public class WithdrawModel(IBankService bankService) : PageModel
     {
         [BindProperty]


### PR DESCRIPTION
Updated model references in Account, CreateAccount, and DeleteAccount views to use respective models instead of previous references from the BankWeb.Pages.AccountsFolder namespace. Changed namespaces in Account, CreateAccount, and DeleteAccount code-behind files from BankWeb.Pages.AccountsFolder to BankWeb.Pages.Accounts. Temporarily disabled the authorization requirement for the "Cashier" role by commenting out the [Authorize(Roles = "Cashier")] attribute in multiple files. Also commented out the User.IsInRole("Cashier") condition in _Layout.cshtml, making the services dropdown menu visible to all users. Updated the connection string in appsettings.json to connect to a different SQL Server instance. Commented out the OnConfiguring method in BankAppDataContext.cs, so the database context will now rely on the connection string provided in the application's configuration instead of a hardcoded string.